### PR TITLE
Update Select2EntityType.php

### DIFF
--- a/Form/Type/Select2EntityType.php
+++ b/Form/Type/Select2EntityType.php
@@ -51,7 +51,7 @@ class Select2EntityType extends AbstractType
                 throw new \Exception('Unable to load class: '.$options['transformer']);
             }
 
-            $transformer = new $options['transformer']($this->em, $options['class']);
+            $transformer = new $options['transformer']($this->em, $options['class'], $options['text_property'], $options['primary_key']);
 
             if (!$transformer instanceof DataTransformerInterface) {
                 throw new \Exception(sprintf('The custom transformer %s must implement "Symfony\Component\Form\DataTransformerInterface"', get_class($transformer)));


### PR DESCRIPTION
Fixed a bug with custom transformer constructor method call which missing two parameters, that bug makes `text_property` and `primary_key` broken when custom transformer specified. Fixed that.